### PR TITLE
resolves startup object reference error.

### DIFF
--- a/Prioritize/LotOfHarmonyPatches.cs
+++ b/Prioritize/LotOfHarmonyPatches.cs
@@ -169,6 +169,7 @@ namespace Prioritize
         public static void Prefix(Designation __instance)
         {
             if (__instance.target == null) return;
+            if (MainMod.save == null) return;
 
             if (__instance.target.HasThing)
             {


### PR DESCRIPTION
that harmony patch can fire while the mod is loading and the static variable MainMod.save is null.